### PR TITLE
fix a typo for autopkgtest

### DIFF
--- a/pbuilder-hookdir/B20autopkgtest
+++ b/pbuilder-hookdir/B20autopkgtest
@@ -65,6 +65,7 @@ if ! which autopkgtest > /dev/null ; then
   ${ADT_OPTIONS:-} --- adt-virt-null || EXIT=$?
 else 
   $newpid_name autopkgtest \
+  -B \
   --output-dir /tmp/buildd/autopkgtest.out \
   --summary-file /tmp/buildd/autopkgtest.summary \
   /tmp/buildd/*/ \

--- a/pbuilder-hookdir/B20autopkgtest
+++ b/pbuilder-hookdir/B20autopkgtest
@@ -65,7 +65,7 @@ if ! which autopkgtest > /dev/null ; then
   ${ADT_OPTIONS:-} --- adt-virt-null || EXIT=$?
 else 
   $newpid_name autopkgtest \
-  -output-dir /tmp/buildd/autopkgtest.out \
+  --output-dir /tmp/buildd/autopkgtest.out \
   --summary-file /tmp/buildd/autopkgtest.summary \
   /tmp/buildd/*/ \
   --- null || EXIT=$?


### PR DESCRIPTION
I think, we also need to provide the location for the freshly build debs but I'm not sure about there path?