### PR TITLE
Test required tools are installed, error if not

### DIFF
--- a/llvm.sh
+++ b/llvm.sh
@@ -10,6 +10,20 @@
 
 set -eux
 
+# Check for required tools
+needed_binaries=(lsb_release wget add-apt-repository)
+missing_binaries=()
+for binary in "${needed_binaries[@]}"; do
+    if ! which $binary &>/dev/null ; then
+        missing_binaries+=($binary)
+    fi
+done
+if [[ ${#missing_binaries[@]} -gt 0 ]] ; then
+    echo "You are missing some tools this script requires: ${missing_binaries[@]}"
+    echo "(hint: apt install lsb-release wget software-properties-common)"
+    exit 4
+fi
+
 # read optional command line argument
 LLVM_VERSION=9
 if [ "$#" -eq 1 ]; then


### PR DESCRIPTION
It seems like every exit path has a unique error code, so I followed that convention and used exit code 4. Also, the code requires a modern bash version (bash 4+) due to using arrays, and it suggests debian-specific packages to install.

This is intended to help users of http://apt.llvm.org/