### PR TITLE
Added currently supported Linux Mint versions

### DIFF
--- a/llvm.sh
+++ b/llvm.sh
@@ -72,6 +72,9 @@ case "$DIST_VERSION" in
     Ubuntu_21.04 )   REPO_NAME="deb http://apt.llvm.org/hirsute/   llvm-toolchain-hirsute$LLVM_VERSION_STRING main" ;;
     Ubuntu_21.10 )   REPO_NAME="deb http://apt.llvm.org/impish/   llvm-toolchain-impish$LLVM_VERSION_STRING main" ;;
 
+    Linuxmint_19* )  REPO_NAME="deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic$LLVM_VERSION_STRING  main" ;;
+    Linuxmint_20* )  REPO_NAME="deb http://apt.llvm.org/focal/    llvm-toolchain-focal$LLVM_VERSION_STRING   main" ;;
+
     * )
     echo "Distribution '$DISTRO' in version '$VERSION' is not supported by this script (${DIST_VERSION})."
         exit 2


### PR DESCRIPTION
They use the same repos as the Ubuntu LTS they're based on. Linux Mint 21 will probably use the Jammy repos when that releases.

I'm going to work on running the BATS tests, though I'm not sure how to add Linux Mint to the tests yet, I'm sure I'll figure it out.