### PR TITLE
llvm.sh: make repo url / dist version configurable

### DIFF
--- a/llvm.sh
+++ b/llvm.sh
@@ -70,27 +70,29 @@ fi
 
 LLVM_VERSION_STRING=${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}
 
+BASE_URL="${LLVM_APT_BASE_URL:-http://apt.llvm.org}"
+
 # find the right repository name for the distro and version
 case "$DIST_VERSION" in
-    Debian_9* )       REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch$LLVM_VERSION_STRING main" ;;
-    Debian_10* )      REPO_NAME="deb http://apt.llvm.org/buster/   llvm-toolchain-buster$LLVM_VERSION_STRING  main" ;;
-    Debian_11* )      REPO_NAME="deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye$LLVM_VERSION_STRING  main" ;;
-    Debian_unstable ) REPO_NAME="deb http://apt.llvm.org/unstable/ llvm-toolchain$LLVM_VERSION_STRING         main" ;;
-    Debian_testing )  REPO_NAME="deb http://apt.llvm.org/unstable/ llvm-toolchain$LLVM_VERSION_STRING         main" ;;
+    Debian_9* )       REPO_NAME="deb $BASE_URL/stretch/  llvm-toolchain-stretch$LLVM_VERSION_STRING main" ;;
+    Debian_10* )      REPO_NAME="deb $BASE_URL/buster/   llvm-toolchain-buster$LLVM_VERSION_STRING  main" ;;
+    Debian_11* )      REPO_NAME="deb $BASE_URL/bullseye/ llvm-toolchain-bullseye$LLVM_VERSION_STRING  main" ;;
+    Debian_unstable ) REPO_NAME="deb $BASE_URL/unstable/ llvm-toolchain$LLVM_VERSION_STRING         main" ;;
+    Debian_testing )  REPO_NAME="deb $BASE_URL/unstable/ llvm-toolchain$LLVM_VERSION_STRING         main" ;;
 
-    Ubuntu_16.04 )    REPO_NAME="deb http://apt.llvm.org/xenial/   llvm-toolchain-xenial$LLVM_VERSION_STRING  main" ;;
-    Ubuntu_18.04 )    REPO_NAME="deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic$LLVM_VERSION_STRING  main" ;;
-    Ubuntu_18.10 )    REPO_NAME="deb http://apt.llvm.org/cosmic/   llvm-toolchain-cosmic$LLVM_VERSION_STRING  main" ;;
-    Ubuntu_19.04 )    REPO_NAME="deb http://apt.llvm.org/disco/    llvm-toolchain-disco$LLVM_VERSION_STRING   main" ;;
-    Ubuntu_19.10 )   REPO_NAME="deb http://apt.llvm.org/eoan/      llvm-toolchain-eoan$LLVM_VERSION_STRING    main" ;;
-    Ubuntu_20.04 )   REPO_NAME="deb http://apt.llvm.org/focal/     llvm-toolchain-focal$LLVM_VERSION_STRING   main" ;;
-    Ubuntu_20.10 )   REPO_NAME="deb http://apt.llvm.org/groovy/    llvm-toolchain-groovy$LLVM_VERSION_STRING  main" ;;
-    Ubuntu_21.04 )   REPO_NAME="deb http://apt.llvm.org/hirsute/   llvm-toolchain-hirsute$LLVM_VERSION_STRING main" ;;
-    Ubuntu_21.10 )   REPO_NAME="deb http://apt.llvm.org/impish/    llvm-toolchain-impish$LLVM_VERSION_STRING main" ;;
-    Ubuntu_22.04 )   REPO_NAME="deb http://apt.llvm.org/jammy/     llvm-toolchain-jammy$LLVM_VERSION_STRING main" ;;
+    Ubuntu_16.04 )    REPO_NAME="deb $BASE_URL/xenial/   llvm-toolchain-xenial$LLVM_VERSION_STRING  main" ;;
+    Ubuntu_18.04 )    REPO_NAME="deb $BASE_URL/bionic/   llvm-toolchain-bionic$LLVM_VERSION_STRING  main" ;;
+    Ubuntu_18.10 )    REPO_NAME="deb $BASE_URL/cosmic/   llvm-toolchain-cosmic$LLVM_VERSION_STRING  main" ;;
+    Ubuntu_19.04 )    REPO_NAME="deb $BASE_URL/disco/    llvm-toolchain-disco$LLVM_VERSION_STRING   main" ;;
+    Ubuntu_19.10 )   REPO_NAME="deb $BASE_URL/eoan/      llvm-toolchain-eoan$LLVM_VERSION_STRING    main" ;;
+    Ubuntu_20.04 )   REPO_NAME="deb $BASE_URL/focal/     llvm-toolchain-focal$LLVM_VERSION_STRING   main" ;;
+    Ubuntu_20.10 )   REPO_NAME="deb $BASE_URL/groovy/    llvm-toolchain-groovy$LLVM_VERSION_STRING  main" ;;
+    Ubuntu_21.04 )   REPO_NAME="deb $BASE_URL/hirsute/   llvm-toolchain-hirsute$LLVM_VERSION_STRING main" ;;
+    Ubuntu_21.10 )   REPO_NAME="deb $BASE_URL/impish/    llvm-toolchain-impish$LLVM_VERSION_STRING main" ;;
+    Ubuntu_22.04 )   REPO_NAME="deb $BASE_URL/jammy/     llvm-toolchain-jammy$LLVM_VERSION_STRING main" ;;
 
-    Linuxmint_19* )  REPO_NAME="deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic$LLVM_VERSION_STRING  main" ;;
-    Linuxmint_20* )  REPO_NAME="deb http://apt.llvm.org/focal/    llvm-toolchain-focal$LLVM_VERSION_STRING   main" ;;
+    Linuxmint_19* )  REPO_NAME="deb $BASE_URL/bionic/   llvm-toolchain-bionic$LLVM_VERSION_STRING  main" ;;
+    Linuxmint_20* )  REPO_NAME="deb $BASE_URL/focal/    llvm-toolchain-focal$LLVM_VERSION_STRING   main" ;;
 
     * )
     echo "Distribution '$DISTRO' in version '$VERSION' is not supported by this script (${DIST_VERSION})."

--- a/llvm.sh
+++ b/llvm.sh
@@ -47,7 +47,7 @@ fi
 
 DISTRO=$(lsb_release -is)
 VERSION=$(lsb_release -sr)
-DIST_VERSION="${DISTRO}_${VERSION}"
+DIST_VERSION="${LLVM_APT_DIST_VERSION:-${DISTRO}_${VERSION}}"
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root!"


### PR DESCRIPTION
Detailed description is in commit messages

In short, this is useful for mirror sites, also this is useful for organization with their own llvm mirror for their CI.

This adds two API passed from env variable: `LLVM_APT_BASE_URL` and `LLVM_APT_DIST_VERSION`

FYI, some available mirror sites for apt.llvm.org is listed at <https://mirrorz.org/list/llvm-apt>

This has been tested by `LLVM_APT_DIST_VERSION=Debian_11 LLVM_APT_BASE_URL=https://mirrors.tuna.tsinghua.edu.cn/llvm-apt ./llvm.sh` in a debian:bullseye container.