### PR TITLE
Update llvm-defaults-bookworm-binaries/config.xml to support bookworm i386 build

### DIFF
--- a/jobs/llvm-defaults-bookworm-binaries/config.xml
+++ b/jobs/llvm-defaults-bookworm-binaries/config.xml
@@ -24,6 +24,7 @@
       <name>architecture</name>
       <values>
         <string>amd64</string>
+        <string>i386</string>
       </values>
     </hudson.matrix.TextAxis>
     <hudson.matrix.TextAxis>


### PR DESCRIPTION
The existing configuration did not build  **i386** binaries for _bookworm_. This PR adds **i386** string in the architecture block to support building **i386** binaries for _bookworm_.
PS: I am very new to the git. Please, feel free to correct my mistakes. Thanks! 