### PR TITLE
llvm.sh workaround missing add-apt-repository in debian trixie

### DIFF
--- a/install-tests/Dockerfile
+++ b/install-tests/Dockerfile
@@ -5,7 +5,11 @@ USER root
 
 # install the required packages
 RUN apt-get update ;\
-    apt-get install -y --no-install-recommends lsb-release wget make gnupg software-properties-common
+    apt-get install -y --no-install-recommends lsb-release wget make gnupg ca-certificates; \
+    DISTRO=$(lsb_release -sc) && \
+    if [ "$DISTRO" != "trixie" ]; then \
+        apt-get install -y --no-install-recommends software-properties-common; \
+    fi
 
 # copy all the scripts
 COPY tmp/ /build/

--- a/install-tests/test.sh
+++ b/install-tests/test.sh
@@ -7,7 +7,7 @@ LLVM_VERSIONS=(16 17 18)
 
 # Linux distributions to be tested
 # the distro names must match to the name of a docker image!
-DISTROS=("debian:buster" "debian:bullseye" "debian:testing" "debian:unstable" "ubuntu:16.04" "ubuntu:18.04" "ubuntu:18.10" "ubuntu:19.04")
+DISTROS=("debian:trixie" "debian:bookworm"  "debian:buster" "debian:bullseye"  "debian:testing" "debian:unstable" "ubuntu:16.04" "ubuntu:18.04" "ubuntu:18.10" "ubuntu:19.04")
 
 # file containing the test suite
 TEST_SUITE=tests.bats
@@ -23,12 +23,15 @@ echo "" >> $TEST_SUITE
 for distro in "${DISTROS[@]}"
 do
   for llvm_version in "${LLVM_VERSIONS[@]}"
-  do
-    echo "@test \"${distro} - llvm ${llvm_version}\" {" >> $TEST_SUITE
-    echo "   build_run ${distro} ${llvm_version} " >> $TEST_SUITE
-    echo "}" >> $TEST_SUITE
-    echo "" >> $TEST_SUITE
-  done
+    do
+    # we skip the test for debian:trixie with llvm 16 since the installation is not working due to unmet dependencies
+      if ! [[  [[ "${distro}" == "debian:trixie" || "${distro}" == "debian:testing" || "${distro}" == "debian:unstable" ]] &&  "${llvm_version}" == "16"  ]]; then
+          echo "@test \"${distro} - llvm ${llvm_version}\" {" >> $TEST_SUITE
+          echo "   build_run ${distro} ${llvm_version} " >> $TEST_SUITE
+          echo "}" >> $TEST_SUITE
+          echo "" >> $TEST_SUITE
+      fi
+    done
 done
 
 # prepare logfile

--- a/llvm.sh
+++ b/llvm.sh
@@ -23,20 +23,7 @@ usage() {
 CURRENT_LLVM_STABLE=19
 BASE_URL="http://apt.llvm.org"
 
-# Check for required tools
-needed_binaries=(lsb_release wget gpg)
-missing_binaries=()
-for binary in "${needed_binaries[@]}"; do
-    if ! which $binary &>/dev/null ; then
-        missing_binaries+=($binary)
-    fi
-done
-if [[ ${#missing_binaries[@]} -gt 0 ]] ; then
-    echo "You are missing some tools this script requires: ${missing_binaries[@]}"
-    echo "(hint: apt install lsb-release wget software-properties-common gnupg)"
-    exit 4
-fi
-
+NEW_DEBIAN_DISTROS =("trixie" )
 # Set default values for commandline arguments
 # We default to the current stable branch of LLVM
 LLVM_VERSION=$CURRENT_LLVM_STABLE
@@ -49,6 +36,36 @@ CODENAME_FROM_ARGUMENTS=""
 # Obtain VERSION_CODENAME and UBUNTU_CODENAME (for Ubuntu and its derivatives)
 source /etc/os-release
 DISTRO=${DISTRO,,}
+
+# Check for required tools
+needed_binaries=(lsb_release wget add-apt-repository gpg)
+missing_binaries=()
+for binary in "${needed_binaries[@]}"; do
+    if ! which $binary &>/dev/null ; then
+        missing_binaries+=($binary)
+    fi
+done
+
+#remove not needed binaries for newer debian distros
+case ${DISTRO} in
+    debian)
+        case ${VERSION_CODENAME} in
+            NEW_DEBIAN_DISTROS)
+            not_needed_binaries_for_newer_debian=(add-apt-repository)
+            for del in ${not_needed_binaries_for_newer_debian[@]}; do
+                missing_binaries=("${missing_binaries[@]/$del}") 
+            done
+            ;;
+        esac
+    ;;
+esac
+
+if [[ ${#missing_binaries[@]} -gt 0 ]] ; then
+    echo "You are missing some tools this script requires: ${missing_binaries[@]}"
+    echo "(hint: apt install lsb-release wget software-properties-common gnupg)"
+    exit 4
+fi
+
 case ${DISTRO} in
     debian)
         # Debian Trixie has a workaround because of
@@ -142,7 +159,6 @@ LLVM_VERSION_STRING=${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}
 # join the repository name
 if [[ -n "${CODENAME}" ]]; then
     REPO_NAME="deb ${BASE_URL}/${CODENAME}/  llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING} main"
-    wget --method=HEAD ${BASE_URL}/${CODENAME}
     # check if the repository exists for the distro and version
     if ! wget --method=HEAD ${BASE_URL}/${CODENAME} &> /dev/null; then
         if [[ -n "${CODENAME_FROM_ARGUMENTS}" ]]; then
@@ -166,14 +182,17 @@ if [[ -z "`apt-key list 2> /dev/null | grep -i llvm`" ]]; then
     # Delete the key in the old format
     apt-key del AF4F7421 || true
 fi
-if [[ "${VERSION_CODENAME}" == "bookworm" ]]; then
+case ${VERSION_CODENAME} in 
+    "bookworm")
     # add it twice to workaround:
     # https://github.com/llvm/llvm-project/issues/62475
     add-apt-repository -y "${REPO_NAME}"
-fi
-if [[ "${VERSION_CODENAME}" == "trixie" ]]; then
-    # workaround missing add-apt-repository in trixie and use new source.list format
-    SOURCES_FILE="/etc/apt/sources.list.d/http_apt_llvm_org_${CODENAME}_-trixie.sources"
+    add-apt-repository -y "${REPO_NAME}"
+    ;;
+
+    NEW_DEBIAN_DISTROS)
+    # workaround missing add-apt-repository in NEW_DEBIAN_DISTROS and use new source.list format
+    SOURCES_FILE="/etc/apt/sources.list.d/http_apt_llvm_org_${CODENAME}_-${VERSION_CODENAME}.sources"
     TEXT_TO_ADD="Types: deb
 Architectures: amd64 arm64
 Signed-By: /etc/apt/trusted.gpg.d/apt.llvm.org.asc
@@ -181,9 +200,12 @@ URIs: ${BASE_URL}/${CODENAME}/
 Suites: llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING}
 Components: main"
     echo "$TEXT_TO_ADD" | tee -a "$SOURCES_FILE" > /dev/null
-else
+    ;;
+
+    *)
     add-apt-repository -y "${REPO_NAME}"
-fi
+    ;;
+esac
 
 apt-get update
 PKG="clang-$LLVM_VERSION lldb-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION"


### PR DESCRIPTION
Since `trixie`no longer contains `software-properties-common`, `llvm.sh` cannot use `add-apt-repository`, see https://github.com/llvm/llvm-project/issues/120608 .

This PR fixes this and allows `llvm.sh`  be executed in `debian:trixie`.

Furthermore, I added `debian:trixie` and `debian:bookwork` to the testing framework `install-tests/test.sh`

For the tests I had to skip `debian:trixie` (aka `debian:testing` /`debian:unstable`)  and `llvm 16` since there are unmet dependencies during installation.
```console
3.958 The following packages have unmet dependencies:
4.183  clangd-16 : Depends: libabsl20220623 (>= 0~20220623.0-1) but it is not installable
4.185  liblldb-16 : Depends: libpython3.11 (>= 3.11.5) but it is not installable
```

The debian tests results are 

```console
ok 1 debian:trixie - llvm 17
ok 2 debian:trixie - llvm 18
ok 3 debian:bookworm - llvm 16
ok 4 debian:bookworm - llvm 17
ok 5 debian:bookworm - llvm 18
ok 6 debian:buster - llvm 16
ok 7 debian:buster - llvm 17
ok 8 debian:buster - llvm 18
ok 9 debian:bullseye - llvm 16
ok 10 debian:bullseye - llvm 17
ok 11 debian:bullseye - llvm 18
ok 10 debian:testing- llvm 17
ok 11 debian:testing- llvm 18
ok 10 debian:unstable- llvm 17
ok 11 debian:unstable- llvm 18
```

but some ubuntu tests fail independent of the llvm version.
The output looks like
```console
not ok 18 ubuntu:16.04 - llvm 16
not ok 19 ubuntu:16.04 - llvm 17
not ok 20 ubuntu:16.04 - llvm 18
ok 21 ubuntu:18.04 - llvm 16
ok 22 ubuntu:18.04 - llvm 17
ok 23 ubuntu:18.04 - llvm 18
not ok 24 ubuntu:18.10 - llvm 16
not ok 25 ubuntu:18.10 - llvm 17
not ok 26 ubuntu:18.10 - llvm 18
not ok 27 ubuntu:19.04 - llvm 16
not ok 28 ubuntu:19.04 - llvm 17
not ok 29 ubuntu:19.04 - llvm 18
```

ubuntu:16.04 fails with similar error messages such as

```console
2.998 W: The repository 'http://apt.llvm.org/xenial llvm-toolchain-xenial-18 Release' does not have a Release file.
2.998 E: Failed to fetch https://apt.llvm.org/xenial/dists/llvm-toolchain-xenial-18/main/binary-amd64/Packages  404  Not Found
2.998 E: Some index files failed to download. They have been ignored, or old ones used instead.
```

and `ubuntu:18.10` and `ubuntu:19.04` both with errors like
```console
 The repository 'http://archive.ubuntu.com/ubuntu disco Release' does not have a Release file.
```

but I think this is unrelated to this PR.