### PR TITLE
test-install.sh: make lit.py path detection resilient

### DIFF
--- a/test-install.sh
+++ b/test-install.sh
@@ -265,11 +265,26 @@ for d in $DISTRO; do
     fi
     echo "
      set -e -v
+     # Find lit.py: prefer the llvm-shipped version, fall back to system lit
+     LIT_PATH=/usr/lib/llvm-$v/build/utils/lit/lit.py
+     if [ ! -f \$LIT_PATH ]; then
+         LIT_PATH=\$(find /usr/lib/llvm-$v -name lit.py 2>/dev/null | head -1)
+     fi
+     if [ -z \$LIT_PATH ] || [ ! -f \$LIT_PATH ]; then
+         LIT_PATH=\$(command -v lit 2>/dev/null || true)
+     fi
+     if [ -z \$LIT_PATH ]; then
+         echo "ERROR: lit.py not found for LLVM $v"
+         echo "Tried: /usr/lib/llvm-$v/build/utils/lit/lit.py, find, and system PATH"
+         echo "Make sure llvm-$v-tools or python3-lit is installed"
+         exit 1
+     fi
+     echo "Using lit: \$LIT_PATH"
      rm -rf check
      git clone https://github.com/opencollab/llvm-toolchain-integration-test-suite.git check
      cd check
      mkdir build && cd build &&
-     cmake -DLIT=/usr/lib/llvm-$v/build/utils/lit/lit.py \
+     cmake -DLIT=\$LIT_PATH \
           -DCLANG_BINARY=/usr/bin/clang-$v \
           -DCLANGD_BINARY=/usr/bin/clangd-$v \
           -DCLANGXX_BINARY=/usr/bin/clang++-$v \


### PR DESCRIPTION
Instead of hardcoding `/usr/lib/llvm-$v/build/utils/lit/lit.py`, try multiple fallback locations:

1. The historical path in `llvm-$v-tools`
2. A `find` in `/usr/lib/llvm-$v/`
3. The system `lit` command (from `python3-lit`)

This fixes the recurring failure in `llvm-toolchain-21-integration-test` where `make check` fails with:
```
make[3]: /usr/lib/llvm-21/build/utils/lit/lit.py: No such file or directory
make[3]: *** [CMakeFiles/check.dir/build.make:70: CMakeFiles/check] Error 127
```

The file is shipped by `llvm-21-tools` but appears to not be available at runtime in certain unstable chroot configurations (possibly after binNMU or when the package gets removed between cmake configure and make).

Also provides a clear error message with instructions when lit cannot be found at all.