### PR TITLE
sync-form-other-arch: don't empty the arch index when there is nothing to import

### DIFF
--- a/sync-form-other-arch.sh
+++ b/sync-form-other-arch.sh
@@ -138,6 +138,42 @@ if [[ -d /tmp/tmp-$DISTRO/pool/main/l/llvm-toolchain/ || -d /tmp/tmp-$DISTRO/poo
         PKG_NAME+="-$DISTRO"
     fi
 
+    # Collect the incoming .deb set before touching the repository. The removal
+    # loop below is destructive and has no rollback: if the includedeb that
+    # follows it ends up with nothing to install, the distribution keeps only
+    # its Architecture: all packages, and clang-N along with every other
+    # arch-specific package disappears from the index until the next successful
+    # sync. The guard above accepts both pool names, so look in both instead of
+    # hardcoding one and letting an unexpanded glob reach reprepro.
+    incoming=()
+    for pool_dir in /tmp/tmp-$DISTRO/pool/main/l/llvm-toolchain-snapshot /tmp/tmp-$DISTRO/pool/main/l/llvm-toolchain; do
+        test -d "$pool_dir" || continue
+        while IFS= read -r deb; do
+            incoming+=("$deb")
+        done < <(find "$pool_dir" -maxdepth 1 -type f -name '*.deb' | sort)
+    done
+
+    if [ ${#incoming[@]} -eq 0 ]; then
+        echo "ERROR: no .deb to import into $PKG_NAME, keeping the current $ARCH packages"
+        exit 1
+    fi
+
+    # _all.deb alone is not enough: the removal below only drops the
+    # arch-specific packages, so importing nothing but Architecture: all would
+    # empty the $ARCH index just the same.
+    arch_debs=0
+    for deb in "${incoming[@]}"; do
+        case "$deb" in
+            *_"$ARCH".deb) arch_debs=$((arch_debs + 1)) ;;
+        esac
+    done
+    if [ "$arch_debs" -eq 0 ]; then
+        echo "ERROR: ${#incoming[@]} .deb found for $PKG_NAME but none built for $ARCH;"
+        echo "       removing the current ones would leave the index without any"
+        exit 1
+    fi
+    echo "Importing ${#incoming[@]} package(s) into $PKG_NAME ($arch_debs for $ARCH)"
+
     # Get the list of packages (but don't get the _all packages)
     LIST=$(reprepro -A $ARCH -Vb /srv/repository/$DISTRO/  listfilter $PKG_NAME  'Architecture (!= all)' | awk '{print $2}')
     echo "Delete $LIST (existing package) on $ARCH before includedeb"
@@ -149,5 +185,11 @@ if [[ -d /tmp/tmp-$DISTRO/pool/main/l/llvm-toolchain/ || -d /tmp/tmp-$DISTRO/poo
     done
 
     # Include the deb package(s)
-    reprepro -Vb /srv/repository/$DISTRO/ includedeb $PKG_NAME /tmp/tmp-$DISTRO/pool/main/l/llvm-toolchain-snapshot/*deb
+    reprepro -Vb /srv/repository/$DISTRO/ includedeb $PKG_NAME "${incoming[@]}"
+
+    # Last chance to notice an empty $ARCH before the repository is synced out.
+    if ! reprepro -A $ARCH -b /srv/repository/$DISTRO/ listfilter $PKG_NAME 'Architecture (!= all)' | grep -q .; then
+        echo "ERROR: $PKG_NAME has no $ARCH package left after the import"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
Follow-up to the "Unable to locate package clang-22" reports on arm64
(llvm/llvm-project#180163 and similar on Debian bookworm).

## Symptom

```
E: Unable to locate package clang-22
```

with an `apt update` that otherwise looks healthy:

```
Get:9 https://apt.llvm.org/bookworm llvm-toolchain-bookworm-22/main arm64 Packages [3199 B]
```

3199 B is the tell. A healthy `llvm-toolchain-bookworm-22` arm64 index is ~22 kB
(86 stanzas). If you take that index and keep **only** the `Architecture: all`
stanzas, it gzips to 3208 B — within noise of what the user received. So the
index was not truncated or corrupt: it contained the 12 `Architecture: all`
packages and **zero** arch-specific ones. `clang-N` is arch-specific, hence the
error. (The `binary-i386` index published today is the same shape — 12748 B
plain, matching an `all`-only index byte for byte in plain size.)

## Cause

The nightly import in `sync-form-other-arch.sh` removes every arch-specific
package from the distribution *before* running `includedeb`, and that sequence
has no rollback:

```sh
LIST=$(reprepro -A $ARCH ... listfilter $PKG_NAME 'Architecture (!= all)' | awk '{print $2}')
for pkg in $LIST; do
    reprepro -A $ARCH ... remove $PKG_NAME $pkg
done
reprepro -Vb /srv/repository/$DISTRO/ includedeb $PKG_NAME /tmp/tmp-$DISTRO/pool/main/l/llvm-toolchain-snapshot/*deb
```

If the `includedeb` ends up with nothing to install, what is left is exactly the
`all`-only distribution above. Two ways to get there:

1. the pool directory rsynced from the build host holds no `.deb`, so `*deb`
   reaches reprepro unexpanded;
2. the guard on the block accepts `pool/main/l/llvm-toolchain/` as well, but the
   `includedeb` only ever looks in `pool/main/l/llvm-toolchain-snapshot/` — same
   unexpanded glob whenever only the former is present.

`set -e` does make the job go red at that point, but the removals have already
been applied to `/srv/repository`, and the distribution stays in that state
until a later run succeeds.

## The change

Collect the incoming `.deb` set first, from both pool names, and refuse to touch
the repository if it is empty or contains no package built for `$ARCH` —
importing nothing but `_all.deb` empties the arch index just as thoroughly,
since the removal loop only drops arch-specific packages. The collected list is
passed to `includedeb` instead of the glob, and the architecture is checked to
be non-empty after the import.

Failing early leaves the previous (working) packages in place, so a bad sync
degrades to "index is stale" instead of "clang-N is gone".

## Testing

`bash -n` is clean. I also ran the block against a stubbed `reprepro` with a
distribution seeded with 3 arch-specific packages:

| case | before this PR | with this PR |
|---|---|---|
| pool has arm64 + `_all` debs | 3 → 2 (import works) | 3 → 2 (unchanged) |
| pool is empty | 3 → 1, index damaged | aborts, stays 3 |
| pool has only `_all` debs | 3 → **0**, index damaged | aborts, stays 3 |

I don't have access to the Jenkins host, so the reproduction is of the script
logic rather than of a real sync.

## Not in this PR

Two other things look worth doing separately, happy to send patches if you want
them:

- **`ByHashes: yes`** in reprepro's `conf/distributions` (server-side, not in
  this repo). The served `Release` has no `Acquire-By-Hash` and no
  `Valid-Until`, and `dists/.../binary-arm64/by-hash/SHA256/<sha>` is a 404.
  With Fastly caching `InRelease` and `Packages.gz` as independent objects
  (I measured `age: 502` vs `age: 271` on the same request pair), an edge node
  can hold an old-but-self-consistent pair long after the origin is fixed —
  which would explain why this looked random across distros, arches and
  regions. by-hash closes that window.
- `sync-to-llvm.sh` calls the Fastly purge API with a bare `curl -XPOST`, so a
  429 or a dropped purge passes unnoticed; `curl -fsS --retry` there, or a
  surrogate-key purge instead of the per-URL loop, would make failures visible.